### PR TITLE
Add comment about where file goes

### DIFF
--- a/common-gs/authenticate.rst
+++ b/common-gs/authenticate.rst
@@ -1,3 +1,5 @@
+.. This is the intro to authenticate topic for API docs that have a Getting Started, move this file to the getting-started folder.
+
 .. _authentication:
 
 Authenticate to the Rackspace Cloud


### PR DESCRIPTION
In API docs, this file goes in the getting-started folder.  Update the getting-started index.rst to make sure the file is included in the contents.